### PR TITLE
fix: use explicit provider_installation config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN adduser -D -h /var/terraform -u 1000 terraform
 USER terraform
 WORKDIR /var/terraform/workspace
 
+# Prepare .terraformrc
+COPY terraformrc /var/terraform/.terraformrc
+RUN mkdir -p /var/terraform/.terraform.d/plugins
+
 # prepare provider plugin mirror for built-in templates
 COPY mirror-plugins.sh .
 RUN ./mirror-plugins.sh

--- a/terraformrc
+++ b/terraformrc
@@ -1,0 +1,6 @@
+provider_installation {
+  filesystem_mirror {
+    path = "/var/terraform/.terraform.d/plugins"
+  }
+  direct {}
+}


### PR DESCRIPTION
Address https://github.com/seal-io/seal/issues/813

When using implicit local mirror, if the provider is present but the version is not, terraform will not install required providers in the direct way.

See https://discuss.hashicorp.com/t/terraform-13-14-fails-to-download-newer-provider-version-if-older-version-exists-locally/25168/2 for details.