### PR TITLE
fix: update template mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN set -eo pipefail; \
     apk add -U --no-cache \
       ca-certificates \
-      curl unzip git bash openssh \
+      curl unzip git bash openssh jq \
     ; \
     rm -rf /var/cache/apk/*;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,10 @@ RUN adduser -D -h /var/terraform -u 1000 terraform
 USER terraform
 WORKDIR /var/terraform/workspace
 
+RUN mkdir -p /var/terraform/.terraform.d/plugin-cache
+
 # Prepare .terraformrc
 COPY terraformrc /var/terraform/.terraformrc
-RUN mkdir -p /var/terraform/.terraform.d/plugins
 
 # prepare provider plugin mirror for built-in templates
 COPY mirror-plugins.sh .

--- a/mirror-plugins.sh
+++ b/mirror-plugins.sh
@@ -25,7 +25,6 @@ for template in templates/*; do
 	if [ -d "$template" ]; then
     # Prepare implied local mirror.
     # See https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories.
-		terraform -chdir="${template}" init && \
-		terraform -chdir="${template}" providers mirror "$HOME/.terraform.d/plugins"
+		terraform -chdir="${template}" init
 	fi
 done

--- a/mirror-plugins.sh
+++ b/mirror-plugins.sh
@@ -1,21 +1,31 @@
 #!/bin/bash
 
+ORG_NAME="walrus-catalog"
+# GitHub API URL
+API_URL="https://api.github.com/orgs/${ORG_NAME}/repos"
+
+# mkdir templates.
+mkdir -p templates
+
 prepare () {
-  git clone https://github.com/seal-io/modules && cd modules
+	repos=$(curl -s "$API_URL")
+	for repo in $(echo "$repos" | jq -r '.[].name'); do
+		git clone https://github.com/${ORG_NAME}/${repo} templates/${repo}
+	done
 }
 
 cleanup () {
-  cd .. && \
-  rm -rf mirror-plugins.sh modules
+  rm -rf mirror-plugins.sh templates
 }
 
 prepare
 trap cleanup INT TERM EXIT
 
-for module_dir in */*/; do
+for template in templates/*; do
+	if [ -d "$template" ]; then
     # Prepare implied local mirror.
     # See https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories.
-    terraform -chdir="$module_dir" init && \
-    terraform -chdir="$module_dir" providers mirror "$HOME/.terraform.d/plugins"
+		terraform -chdir="${template}" init && \
+		terraform -chdir="${template}" providers mirror "$HOME/.terraform.d/plugins"
+	fi
 done
-

--- a/terraformrc
+++ b/terraformrc
@@ -1,6 +1,1 @@
-provider_installation {
-  filesystem_mirror {
-    path = "/var/terraform/.terraform.d/plugins"
-  }
-  direct {}
-}
+plugin_cache_dir = "/var/terraform/.terraform.d/plugin-cache"


### PR DESCRIPTION
This PR is going:
- As templates moved  to walrus catalog, the build script need to be modified.
- Remove terraform config `provider_installation `. The reason is that terraform will only use the mirror dir to get providers and their versions. If the template providers version is not mirrored to the mirror dir, it will cause deployment failed. And the config of the previous version is not work as the `direct` config makes all providers download from terraform registry.
- Add provider cache dir. Although, the deployer can not deploy without network, but the cached provider zip files can reduce builtin template download provider every time. https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache