### PR TITLE
feat: avoid Terraform non-provider files warnings

### DIFF
--- a/mirror-plugins.sh
+++ b/mirror-plugins.sh
@@ -19,3 +19,5 @@ for module_dir in */*/; do
     terraform -chdir="$module_dir" providers mirror "$HOME/.terraform.d/plugins"
 done
 
+# Remove non-provider plugin files to avoid Terraform warnings.
+find /var/terraform/.terraform.d/plugins -type f ! -name "terraform-provider-*" -delete


### PR DESCRIPTION
<img width="1309" alt="image" src="https://github.com/seal-io/terraform-deployer/assets/45061862/989e72c1-0d47-4722-95c2-768f165d6f3d">
Only need keep the provider plugin file. Remove the json files to avoid Terraform warnings like:

```
2023-07-31T07:20:31.047Z [WARN]  ignoring file "registry.terraform.io/hashicorp/random/3.5.1.json" as possible package for registry.terraform.io/hashicorp/random: filename lacks expected prefix "terraform-provider-random_"
2023-07-31T07:20:31.047Z [WARN]  ignoring file "registry.terraform.io/hashicorp/random/index.json" as possible package for registry.terraform.io/hashicorp/random: filename lacks expected prefix "terraform-provider-random_"
...
```

